### PR TITLE
Fixed stale dependency on an older version of lager_syslog, which was…

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
 {deps, [
         {rebar_lock_deps_plugin, ".*", {git, "https://github.com/basho/rebar_lock_deps_plugin.git", {branch, "master"}}},
         {node_package, ".*", {git, "https://github.com/basho/node_package.git", {tag, "4.0.1"}}},
-        {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog.git", {tag, "2.0.3"}}},
+        {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog.git", {tag, "3.0.3"}}},
         {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {branch, "develop"}}},
         {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "develop"}}},
         {riak_search, ".*", {git, "git://github.com/basho/riak_search.git", {branch, "develop"}}},


### PR DESCRIPTION
… pulling in an ancient version of lager, which was causing riaknostic to fail to build.

Bringing in Fred's change from upstream